### PR TITLE
Add SQLFluff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # dbt-facebook-meltano-sdk
+
+
+## SQLFluff Linting
+
+This repo has SQLFluff configured for linting.
+See https://docs.sqlfluff.com/en/stable/index.html for more details.
+
+Install SQLFluff into a virtualenv and export the required profile env vars needed to connect to the warehouse.
+
+```bash
+# Install SQLFluff and dbt
+pip install sqlfluff==2.0.3 sqlfluff-templater-dbt==2.0.3 dbt-core~=1.3.0 dbt-snowflake~=1.3.0
+
+# Export env vars needed for dbt
+export DBT_SNOWFLAKE_ACCOUNT=<>
+export DBT_SNOWFLAKE_USER=<>
+export DBT_SNOWFLAKE_PASSWORD=<>
+export DBT_SNOWFLAKE_ROLE=<>
+export DBT_SNOWFLAKE_WAREHOUSE=<>
+export DBT_SNOWFLAKE_DATABASE=<>
+export DBT_SNOWFLAKE_SCHEMA=<>
+
+# Run SQLFluff against the models
+sqlfluff lint Snowflake/models/
+sqlfluff fix Snowflake/models/
+```
+
+

--- a/Snowflake/.sqlfluff
+++ b/Snowflake/.sqlfluff
@@ -1,0 +1,20 @@
+[sqlfluff]
+dialect = snowflake
+templater = dbt
+runaway_limit = 100
+# Bug https://github.com/sqlfluff/sqlfluff/issues/4188
+# exclude_rules = L071
+
+[sqlfluff:templater:dbt]
+project_dir = .
+profiles_dir = profiles/snowflake/
+profile = meltano
+
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = upper
+
+[sqlfluff:rules:capitalisation.identifiers]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:capitalisation.functions]
+capitalisation_policy = upper


### PR DESCRIPTION
@NeilGorman104 based on my comments from https://github.com/ryan-miranda-partners/dbt-facebook-meltano-sdk/issues/8. This adds SQLFluff for linting of your SQL to make sure its compliant with the style guide. We use this same configuration in our internal [Squared project](https://github.com/meltano/squared/tree/main/data/transform).

Let me know if you have any questions!