### PR TITLE
DATA-3278 Updated ad tracking and custom audience history

### DIFF
--- a/Snowflake/models/tap_facebook/ad_tracking.sql
+++ b/Snowflake/models/tap_facebook/ad_tracking.sql
@@ -24,67 +24,106 @@ lateral flatten(input=>CREATIVE) json
 {% set json_column_query %}
 select distinct json.key as column_name
 
-FROM {{ source('tap_facebook', 'ads')}},
+FROM (SELECT REPLACE(ARRAY_TO_STRING(ARRAY_SLICE(PARSE_JSON(TRACKING_SPECS), 1, 2), ''), '.', '_') as TRACKING_COLUMNS FROM {{ source('tap_facebook', 'ads') }}),
 
-lateral flatten(input=>TRACKING_SPECS[0]) json
+lateral flatten(input=>PARSE_JSON(TRACKING_COLUMNS)) json
 {% endset %}
  
-{% set tracking_specs_results = run_query(json_column_query) %}
+{% set tracking_results = run_query(json_column_query) %}
 
 {% if execute %}
 {# Return the first column #}
-{% set tracking_sepcs_list = tracking_specs_results.columns[0].values() %}
+{% set tracking_list = tracking_results.columns[0].values() %}
 {% else %}
-{% set tracking_sepcs_list = [] %}
+{% set tracking_list = [] %}
 {% endif %}
  
-SELECT ACCOUNT_ID,
-       ADSET_ID,
-       CAMPAIGN_ID,
-       TO_TIMESTAMP_NTZ(CREATED_TIME, 'YYYY-MM-DD"T"HH24:MI:SSTZHTZM') as CREATED_TIME,
+
+SELECT AD_ID,
+       AD_UPDATED_TIME,
+       APPLICATION,
+       "TRACKING_COLUMNS_conversion_id" as CONVERSION_ID,
        CREATIVE,
-       ID,
-       NAME,
-       TRACKING_SPECS,
-       TO_TIMESTAMP_NTZ(UPDATED_TIME, 'YYYY-MM-DD"T"HH24:MI:SSTZHTZM') as UPDATED_TIME,
-       _SDC_BATCHED_AT,
+       DATASET,
+       EVENT,
+       EVENT_TYPE,
+       "TRACKING_COLUMNS_fb_pixel" as FB_PIXEL,
+       FB_PIXEL_EVENT,
+       LEADGEN,
+       OBJECT,
+       OFFER,
+       OFFSITE_PIXEL,
+       "TRACKING_COLUMNS_page" as PAGE,
+       "TRACKING_COLUMNS_post" as POST,
+       QUESTION,
+       RESPONSE,
+       SUBTYPE,
+       "TRACKING_COLUMNS_action_type" as ACTION_TYPE,
+       EVENT_CREATOR,
+       OBJECT_DOMAIN,
+       OFFER_CREATOR,
+       PAGE_PARENT,
+       POST_OBJECT_WALL,
+       "TRACKING_COLUMNS_post_wall" as POST_WALL,
+       POST_OBJECT,
+       QUESTION_CREATOR
 
-/*TODO: Add columns 'Action_type',
-'Conversion_id',
-APPLICATION,
-DATASET,
-EVENT,
-EVENT_CREATOR,
-EVENT_TYPE,
-FB_PIXEL,
-FB_PIXEL_EVENT,
-INDEX,
-LEADGEN,
-OBJECT,
-OBJECT_DOMAIN,
-OFFER,
-OFFER_CREATOR,
-OFFSITE_PIXEL,
-PAGE,
-PAGE_PARENT,
-POST,
-POST_OBJECT,
-POST_OBJECT_WALL,
-POST_WALL,
-QUESTION,
-QUESTION_CREATOR,
-RESPONSE,
-SUBTYPE,
-*/
+FROM (SELECT AD_ID,
+             AD_UPDATED_TIME,
+             APPLICATION,
+             CREATIVE
+             DATASET,
+             EVENT,
+             EVENT_CREATOR,
+             EVENT_TYPE,
+             FB_PIXEL_EVENT,
+             LEADGEN,
+             OBJECT,
+             OBJECT_DOMAIN,
+             OFFER,
+             OFFER_CREATOR,
+             OFFSITE_PIXEL,
+             PAGE_PARENT,
+             POST_OBJECT,
+             POST_OBJECT_WALL,
+             QUESTION,
+             QUESTION_CREATOR,
+             RESPONSE,
+             SUBTYPE,
 
+       {% for column_name in tracking_list %}
+       PARSE_JSON(TRACKING_COLUMNS):{{column_name}}::varchar as "TRACKING_COLUMNS_{{column_name}}"{%- if not loop.last %},{% endif -%}
+       {% endfor %},
 
-{% for column_name in creative_list %}
-CREATIVE:{{column_name}}::varchar as "CREATIVE_ID"{%- if not loop.last %},{% endif -%}
-{% endfor %},
+       CREATIVE
 
-{% for column_name in tracking_sepcs_list %}
-TRACKING_SPECS:{{column_name}}::varchar as "TRACKING_SPECS_{{column_name}}"{%- if not loop.last %},{% endif -%}
-{% endfor %}
+FROM (SELECT ID as AD_ID,
+             APPLICATION,
+             DATASET,
+             EVENT,
+             EVENT_CREATOR,
+             EVENT_TYPE,
+             FB_PIXEL_EVENT,
+             LEADGEN,
+             OBJECT,
+             OBJECT_DOMAIN,
+             OFFER,
+             OFFER_CREATOR,
+             OFFSITE_PIXEL,
+             PAGE_PARENT,
+             POST_OBJECT,
+             POST_OBJECT_WALL,
+             QUESTION,
+             QUESTION_CREATOR,
+             RESPONSE,
+             SUBTYPE,
+             REPLACE(ARRAY_TO_STRING(ARRAY_SLICE(PARSE_JSON(TRACKING_SPECS), 1, 2), ''), '.', '_') as TRACKING_COLUMNS,
+       
+             TO_TIMESTAMP_NTZ(UPDATED_TIME, 'YYYY-MM-DD"T"HH24:MI:SSTZHTZM') as AD_UPDATED_TIME,
 
-FROM {{ source('tap_facebook', 'ads') }} as ad_tracking
+             {% for column_name in creative_list %}
+             CREATIVE:{{column_name}}::varchar as "CREATIVE"{%- if not loop.last %},{% endif -%}
+             {% endfor %}
 
+FROM {{ source('tap_facebook', 'ads') }} as meltano_ad_tracking))
+ 

--- a/Snowflake/models/tap_facebook/custom_audience_history.sql
+++ b/Snowflake/models/tap_facebook/custom_audience_history.sql
@@ -1,11 +1,98 @@
 {{
    config(
-     materialized='table'
+     materialized='view'
    )
 }}
+
+{% set json_column_query %}
+select distinct json.key as column_name
+
+FROM {{ source('tap_facebook', 'customaudiences') }},
+
+lateral flatten(input=>PARSE_JSON(DATA_SOURCE)) json
+{% endset %}
+ 
+{% set datasource_results = run_query(json_column_query) %}
+
+{% if execute %}
+{# Return the first column #}
+{% set datasource_list = datasource_results.columns[0].values() %}
+{% else %}
+{% set datasource_list = [] %}
+{% endif %}
+
+{% set json_column_query %}
+select distinct json.key as column_name
+
+FROM {{ source('tap_facebook', 'customaudiences') }},
+
+lateral flatten(input=>PARSE_JSON(DELIVERY_STATUS)) json
+{% endset %}
+ 
+{% set deliverystatus_results = run_query(json_column_query) %}
+
+{% if execute %}
+{# Return the first column #}
+{% set deliverystatus_list = deliverystatus_results.columns[0].values() %}
+{% else %}
+{% set deliverystatus_list = [] %}
+{% endif %}
+
+{% set json_column_query %}
+select distinct json.key as column_name
+
+FROM {{ source('tap_facebook', 'customaudiences') }},
+
+lateral flatten(input=>PARSE_JSON(OPERATION_STATUS)) json
+{% endset %}
+ 
+{% set operationstatus_results = run_query(json_column_query) %}
+
+{% if execute %}
+{# Return the first column #}
+{% set operationstatus_list = operationstatus_results.columns[0].values() %}
+{% else %}
+{% set operationstatus_list = [] %}
+{% endif %}
+
+{% set json_column_query %}
+select distinct json.key as column_name
+
+FROM {{ source('tap_facebook', 'customaudiences') }},
+
+lateral flatten(input=>PARSE_JSON(PERMISSION_FOR_ACTIONS)) json
+{% endset %}
+ 
+{% set permission_results = run_query(json_column_query) %}
+
+{% if execute %}
+{# Return the first column #}
+{% set permission_list = permission_results.columns[0].values() %}
+{% else %}
+{% set permission_list = [] %}
+{% endif %}
  
 SELECT ID,
+       UPDATED_TIME,
        ACCOUNT_ID,
+       APPROXIMATE_COUNT_LOWER_BOUND,
+       APPROXIMATE_COUNT_UPPER_BOUND,
+       CUSTOMER_FILE_SOURCE,
+       DESCRIPTION,
+       IS_VALUE_BASED,
+       NAME,
+       OPT_OUT_LINK,
+       PIXEL_ID,
+       RETENTION_DAYS,
+       RULE,
+       RULE_AGGREGATION,
+       SUBTYPE,
+       CREATION_PARAMS as DATA_SOURCE_CREATION_PARAMS,
+       SUB_TYPE as DATA_SOURCE_SUB_TYPE,
+       TYPE as DATA_SOURCE_TYPE,
+       "DELIVERY_STATUS_code"::number as DELIVERY_STATUS_CODE,
+       "DELIVERY_STATUS_description" as DELIVERY_STATUS_DESCRIPTION,
+       EXTERNAL_EVENT_SOURCE_ID,
        EXTERNAL_EVENT_SOURCE_AUTOMATIC_MATCHING_FIELDS,
        EXTERNAL_EVENT_SOURCE_CAN_PROXY,
        EXTERNAL_EVENT_SOURCE_CODE,
@@ -13,7 +100,6 @@ SELECT ID,
        EXTERNAL_EVENT_SOURCE_DATA_USE_SETTING,
        EXTERNAL_EVENT_SOURCE_ENABLE_AUTOMATIC_MATCHING,
        EXTERNAL_EVENT_SOURCE_FIRST_PARTY_COOKIE_STATUS,
-       EXTERNAL_EVENT_SOURCE_ID,
        EXTERNAL_EVENT_SOURCE_IS_CREATED_BY_BUSINESS,
        EXTERNAL_EVENT_SOURCE_IS_CRM,
        EXTERNAL_EVENT_SOURCE_IS_UNAVAILABLE,
@@ -24,9 +110,74 @@ SELECT ID,
        LOOKALIKE_ORIGIN_EVENT_NAME,
        LOOKALIKE_ORIGIN_EVENT_SOURCE_NAME,
        LOOKALIKE_PRODUCT_SET_NAME,
-       CAST(LOOKALIKE_RATIO as float) as LOOKALIKE_RATIO,
-       CAST(LOOKALIKE_STARTING_RATIO as float) as LOOKALIKE_STARTING_RATIO,
+       LOOKALIKE_RATIO,
+       LOOKALIKE_STARTING_RATIO,
        LOOKALIKE_TYPE,
-       RULE_AGGREGATION
+       "OPERATION_STATUS_code"::number as OPERATION_STATUS_CODE,
+       "OPERATION_STATUS_description" as OPERATION_STATUS_DESCRIPTION,
+       CAST("PERMISSION_FOR_ACTIONS_can_edit" as boolean) as PERMISSION_FOR_ACTIONS_CAN_EDIT,
+       CAST("PERMISSION_FOR_ACTIONS_can_see_insight" as boolean) as PERMISSION_FOR_ACTIONS_CAN_SEE_INSIGHT,
+       CAST("PERMISSION_FOR_ACTIONS_can_share" as boolean) as PERMISSION_FOR_ACTIONS_CAN_SHARE,
+       CAST("PERMISSION_FOR_ACTIONS_subtype_supports_lookalike" as boolean) as PERMISSION_FOR_ACTIONS_SUBTYPE_SUPPORTS_LOOKALIKE,
+       CAST("PERMISSION_FOR_ACTIONS_supports_recipient_lookalike" as boolean) as PERMISSION_FOR_ACTIONS_SUPPORTS_RECIPIENT_LOOKALIKE,
+       CONTENT_UPDATED_TIME,
+       CREATED_TIME
+FROM (SELECT ID,
+             CAST(TIME_UPDATED as datetime) as UPDATED_TIME,
+             ACCOUNT_ID,
+             APPROXIMATE_COUNT_LOWER_BOUND,
+             APPROXIMATE_COUNT_UPPER_BOUND,
+             CUSTOMER_FILE_SOURCE,
+             DESCRIPTION,
+             IS_VALUE_BASED,
+             NAME,
+             OPT_OUT_LINK,
+             PIXEL_ID,
+             RETENTION_DAYS,
+             RULE,
+             RULE_AGGREGATION,
+             SUBTYPE,
 
-FROM {{ source('tap_facebook', 'customaudiences') }} as meltano_custom_audiences
+             {% for column_name in datasource_list %}
+             PARSE_JSON(DATA_SOURCE):{{column_name}}::varchar as {{column_name}}{%- if not loop.last %},{% endif -%}
+             {% endfor %},
+
+             {% for column_name in deliverystatus_list %}
+             PARSE_JSON(DELIVERY_STATUS):{{column_name}}::varchar as "DELIVERY_STATUS_{{column_name}}"{%- if not loop.last %},{% endif -%}
+             {% endfor %},
+
+             EXTERNAL_EVENT_SOURCE_ID,
+             EXTERNAL_EVENT_SOURCE_AUTOMATIC_MATCHING_FIELDS,
+             EXTERNAL_EVENT_SOURCE_CAN_PROXY,
+             EXTERNAL_EVENT_SOURCE_CODE,
+             EXTERNAL_EVENT_SOURCE_CREATION_TIME,
+             EXTERNAL_EVENT_SOURCE_DATA_USE_SETTING,
+             EXTERNAL_EVENT_SOURCE_ENABLE_AUTOMATIC_MATCHING,
+             EXTERNAL_EVENT_SOURCE_FIRST_PARTY_COOKIE_STATUS,
+             EXTERNAL_EVENT_SOURCE_IS_CREATED_BY_BUSINESS,
+             EXTERNAL_EVENT_SOURCE_IS_CRM,
+             EXTERNAL_EVENT_SOURCE_IS_UNAVAILABLE,
+             EXTERNAL_EVENT_SOURCE_LAST_FIRED_TIME,
+             EXTERNAL_EVENT_SOURCE_NAME,
+             LOOKALIKE_COUNTRY,
+             LOOKALIKE_IS_FINANCIAL_SERVICE,
+             LOOKALIKE_ORIGIN_EVENT_NAME,
+             LOOKALIKE_ORIGIN_EVENT_SOURCE_NAME,
+             LOOKALIKE_PRODUCT_SET_NAME,
+             CAST(LOOKALIKE_RATIO as float) as LOOKALIKE_RATIO,
+             CAST(LOOKALIKE_STARTING_RATIO as float) as LOOKALIKE_STARTING_RATIO,
+             LOOKALIKE_TYPE,
+
+             {% for column_name in operationstatus_list %}
+             PARSE_JSON(OPERATION_STATUS):{{column_name}}::varchar as "OPERATION_STATUS_{{column_name}}"{%- if not loop.last %},{% endif -%}
+             {% endfor %},
+
+             {% for column_name in permission_list %}
+             PARSE_JSON(PERMISSION_FOR_ACTIONS):{{column_name}}::varchar as "PERMISSION_FOR_ACTIONS_{{column_name}}"{%- if not loop.last %},{% endif -%}
+             {% endfor %},
+
+             CAST(TIME_CONTENT_UPDATED as datetime) as CONTENT_UPDATED_TIME,
+             CAST(TIME_CREATED as datetime) as CREATED_TIME
+
+FROM {{ source('tap_facebook', 'customaudiences') }} as meltano_custom_audiences)
+ 


### PR DESCRIPTION
Description:
This PR is for updating ad tracking and custom audience history dbt models

Changes:
1. Dnested tracking specs columns in ad tracking dbt model
2. Dnested data source, delivery status, operation status, permission for actions columns in custom audience history dbt model

Jira:
https://ryan-miranda.atlassian.net/browse/DATA-3278?atlOrigin=eyJpIjoiN2QwMThkZTczNmFmNGQ3OGI5MTUwNzcwNDUyOGVlNmEiLCJwIjoiaiJ9